### PR TITLE
Add PostgreSQL connection using environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.env
+.DS_Store
+dist
+build
+.vscode

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,9 @@
 PORT=4000
+
+# Example environment variables . 
+
+DB_USER=
+DB_HOST=localhost
+DB_NAME=launch
+DB_PASSWORD=
+DB_PORT=5432

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -1,11 +1,16 @@
 import pkg from "pg"
+import dotenv from "dotenv";
+
+dotenv.config();
+
 const {Pool} =pkg
+
 const pool = new Pool({
-  user: "aida",
-  host: "localhost",
-  database: "Launch",
-  password: "",
-  port: 5432
+  user: process.env.DB_USER,
+  host: process.env.DB_HOST,
+  database: process.env.DB_NAME,
+  password: process.env.DB_PASSWORD,
+  port: process.env.DB_PORT
 });
 
 export default pool;


### PR DESCRIPTION
**Summary**

This PR adds the PostgreSQL database configuration using _environment variables._

**Changes**

* Added PostgreSQL connection using `pg` Pool
* Loaded environment variables using `dotenv`
* Added `.env.example` for environment configuration
* Added `.gitignore` to exclude `.env` from version control

**Notes**

Team members should copy `.env.example` and create their own `.env` file with their local database credentials.
