### PR TITLE
Fix: Remove the ports: mapping from the frontend service.

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -55,7 +55,7 @@ services:
       dockerfile: Dockerfile.prod
     restart: unless-stopped
     ports:
-      - "${FRONTEND_PORT:-80}:8080"
+      - "${FRONTEND_PORT:-8080}:8080"
     depends_on:
       backend:
         condition: service_healthy


### PR DESCRIPTION
Coolify's own Traefik reverse proxy already takes Port 80. Shouldn't bind port 80 directly — Coolify handles all incoming traffic and routes it to your container internally.